### PR TITLE
BRMS Integration Part 2

### DIFF
--- a/R/model-evaluation.R
+++ b/R/model-evaluation.R
@@ -1,5 +1,5 @@
 #' @export
-evaluate_resampling <- function(model, data, metrics = list(yardstick::rmse), v = 10, repeats = 1) {
+evaluate_resampling <- function(model, data, metrics = list(yardstick::rmse), v = nrow(data), repeats = 1) {
   training_split <- rsample::vfold_cv(data, v = v, repeats = repeats)
   metrics <- do.call(yardstick::metric_set, metrics)
   res <- lapply(training_split$splits, function(split) {

--- a/R/model-interface.R
+++ b/R/model-interface.R
@@ -88,7 +88,7 @@ brms_model <- function(formula, family, ...) {
           data = data,
           family = .(family), ...
         )
-        list(
+        res <- list(
           model = model,
           predict = function(newdata, alpha = 0.05) {
             res <- add_prediction_interval(
@@ -100,6 +100,8 @@ brms_model <- function(formula, family, ...) {
             append_observed_column(res, res[[col_name]])
           }
         )
+        class(res) <- c("epichange_model_fit", class(res))
+        res
       }
     ))),
     class = c("epichange_brms_nb", "epichange_model")

--- a/R/model-interface.R
+++ b/R/model-interface.R
@@ -32,7 +32,7 @@
 #' @author Dirk Schumacher
 #'
 #' @aliases epichange_model epichange_models
-#' 
+#'
 #' @export
 #' @rdname epichange_model
 #' @aliases glm_model
@@ -45,7 +45,7 @@ glm_model <- function(formula, family, ...) {
         model_fit(model, formula)
       }
     ))),
-    class = c("epichange_model", "epichange_glm")
+    class = c("epichange_glm", "epichange_model")
   )
 }
 
@@ -59,7 +59,7 @@ glm_nb_model <- function(formula, ...) {
         model_fit(model, formula)
       }
     ))),
-    class = c("epichange_model", "epichange_glm_nb")
+    class = c("epichange_glm_nb", "epichange_model")
   )
 }
 
@@ -73,7 +73,7 @@ lm_model <- function(formula, ...) {
         model_fit(model, formula)
       }
     ))),
-    class = c("epichange_model", "epichange_lm")
+    class = c("epichange_lm", "epichange_model")
   )
 }
 
@@ -110,7 +110,7 @@ brms_model <- function(formula, family, ...) {
         )
       }
     ))),
-    class = c("epichange_model", "epichange_brms_nb")
+    class = c("epichange_brms_nb", "epichange_model")
   )
 }
 

--- a/inst/pathways_analysis.R
+++ b/inst/pathways_analysis.R
@@ -62,7 +62,7 @@ plot(res_overall_k7, "date")
 counts_nhs_region <- pathways_recent %>%
   group_by(nhs_region, date, day, weekday) %>%
   summarise(count = sum(count)) %>%
-  complete(date, fill = list(count = 0)) %>% 
+  complete(date, fill = list(count = 0)) %>%
   split(.$nhs_region)
 
 res_nhs_region <- lapply(counts_nhs_region,
@@ -88,7 +88,7 @@ cowplot::plot_grid(plotlist = plots_nhs_region)
 counts_ccg <- pathways_recent %>%
   group_by(ccg_name, date, day, weekday) %>%
   summarise(count = sum(count)) %>%
-  complete(date, fill = list(count = 0)) %>% 
+  complete(date, fill = list(count = 0)) %>%
   split(.$ccg_name)
 
 res_ccg <- lapply(counts_ccg,
@@ -112,7 +112,7 @@ ccg_stats <- lapply(res_ccg, function(e)
           desc(k))
 
 ccg_stats %>%
-  mutate(p_value = format.pval(p_value, digits = 3)) %>% 
+  mutate(p_value = format.pval(p_value, digits = 3)) %>%
   DT::datatable(ccg_stats, rownames = FALSE)
 
 
@@ -127,5 +127,3 @@ plots_ccg_top <- lapply(seq_along(res_ccg_top),
                              plot(res_ccg_top[[i]], "date", point_size = 1, guide = FALSE) +
                                labs(subtitle = names(res_ccg_top)[i]))
 cowplot::plot_grid(plotlist = plots_ccg_top)
-
-


### PR DESCRIPTION
This closes #13 

It improves the `brms` integration. I also showcased in `inst/repl` how to use `brms` for the current analysis. Training takes quite some time, but prediction is fast enough if you cache the compiled model.

It also now also uses `n-fold` CV with resampling is used. My gut feeling tells me this is a good default for these short time series we are dealing with. TODO: Read some papers about time series model validation.

The nice thing is that this framework gives us good prediction intervals regardless of the response time.

It uses the default `brms` priors but performances really good and is often selected in CV over other models. But we also need to look into `brms` what is actually generated here.